### PR TITLE
android scanner to react only to beacons

### DIFF
--- a/androidScanner/app/build.gradle
+++ b/androidScanner/app/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.1'
     implementation 'org.eclipse.paho:org.eclipse.paho.android.service:1.1.1'
 
+    implementation 'com.neovisionaries:nv-bluetooth:1.8'
+
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'


### PR DESCRIPTION
From now on android scanner handles only those signals that are coming from iBeacon or EddystoneUID (other Eddystones can be easily added later). 